### PR TITLE
fix wrong return statement syntax in 'undo' function

### DIFF
--- a/crepl.v
+++ b/crepl.v
@@ -193,7 +193,7 @@ fn (mut r CREPL) line() ?string {
 	return rline
 }
 
-fn (mut r CREPL) undo()? {
+fn (mut r CREPL) undo()! {
 	if r.current_idx <= 0 {
 		return error('')
 	} else {


### PR DESCRIPTION
To return errors, the syntax is `!Foo`.
To return other types, the the syntax `?Foo`.